### PR TITLE
Add option to stop a running selenium-standalone server when grunt exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ grunt.initConfig({
                   arch: process.arch,
                   baseURL: 'http://selenium-release.storage.googleapis.com'
                 }
-            }
+            },
+            stopOnExit: true
         }
     }
 });
@@ -54,6 +55,10 @@ The supported command verbs are:
 - *install*: installs the web drivers which were specified for a given target
 - *start*: starts the selenium server
 - *stop*: stops the selenium server
+
+### stopOnExit
+
+For each target you can specify if the selenium server should stop automatically when the called grunt task completes or fails. The default is `false`.
 
 ## Contributing
 

--- a/tasks/selenium_standalone.js
+++ b/tasks/selenium_standalone.js
@@ -31,6 +31,7 @@ var withSeleniumContext = function(grunt, performTask) {
 };
 
 var start = function start(grunt) {
+    var that = this;
 	withSeleniumContext.call(this, grunt, function(drivers) {
 		return q.denodeify(selenium.start)({
             version: this.data.seleniumVersion,
@@ -43,14 +44,21 @@ var start = function start(grunt) {
 			seleniumProcess.stderr.on('data', function(data) {
 				grunt.log.debug(data.toString());
 			});
+            if (that.data.stopOnExit === true) {
+                process.on('exit', function () {
+                    stop.call(that, grunt);
+                });
+            }
 		});
 	});
 };
 
 var stop = function stop(grunt) {
-	grunt.log.debug('Killing Selenium server child process...');
-	seleniumChildProcess.kill();
-	grunt.log.debug('Selenium server killed.');
+    if (seleniumChildProcess.kill) {
+        grunt.log.debug('Killing Selenium server child process...');
+        seleniumChildProcess.kill();
+        grunt.log.debug('Selenium server killed.');
+    }
 };
 
 var install = function install(grunt) {

--- a/tasks/selenium_standalone.js
+++ b/tasks/selenium_standalone.js
@@ -33,6 +33,7 @@ var withSeleniumContext = function(grunt, performTask) {
 var start = function start(grunt) {
 	withSeleniumContext.call(this, grunt, function(drivers) {
 		return q.denodeify(selenium.start)({
+            version: this.data.seleniumVersion,
 			drivers: drivers,
 			logger: function(message) {
 				grunt.log.debug(message);


### PR DESCRIPTION
If a task in grunt fails in between selenium_standalone:target:start and selenium_standalone:target:stop, causing grunt to exit before the stop call, the selenium_standalone server process was never being stopped. This PR adds a flag to handle process.on('exit' to make sure a running task is stopped. Also placed a conditional around the stop to make sure the kill function wasn't called if it didn't exist.
